### PR TITLE
Refactor result rendering, increase buffer size for accepted files.

### DIFF
--- a/web-service/.gitignore
+++ b/web-service/.gitignore
@@ -1,0 +1,1 @@
+project

--- a/web-service/file_upload.go
+++ b/web-service/file_upload.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 	// TODO Make sure "NLP" is seen here.
-	// I want to see where the module comes from, not guess.
 	// See how guuid is imported
 	"project/python_wrappers"
 	guuid "github.com/google/uuid"
@@ -28,7 +27,6 @@ func init() {
 	}
 
 	if _, err := os.Stat("uploaded"); os.IsNotExist(err) {
-		// TODO 0777 is too much privilege, but it does not work with 0666.
 		err := os.Mkdir("uploaded", 0777)
 		if err != nil {
 			log.Fatal(err)
@@ -69,7 +67,7 @@ func viewSimilarity(w http.ResponseWriter, req *http.Request) {
 	var result [][]float32
 	// If we are not ready, deny of service and halt
 	if result, ok = UUIDResult[id]; ok == false {
-		fmt.Printf("Result for %s is not yet ready", id);
+		fmt.Fprintf(w, "Result for %s is not found.", id);
 		return
 	}
 	// Serve the result.
@@ -87,8 +85,8 @@ func uploadFiles(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	const _32K = (1 << 10) * 32
-	if err = req.ParseMultipartForm(_32K); nil != err {
+	const _5M = (1 << 20) * 5
+	if err = req.ParseMultipartForm(_5M); nil != err {
 		http.Error(w, "507 - Maximum upload size limit exceeded!", http.StatusInsufficientStorage)
 		return
 	}
@@ -109,7 +107,7 @@ func uploadFiles(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		// 32K buffer copy
+		// 5M buffer copy
 		if _, err = io.Copy(outfile, infile); nil != err {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			ErrorLogger.Println(err)
@@ -117,9 +115,9 @@ func uploadFiles(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	// Report a link to the personal room
 	id := guuid.New()
 	go prepareViewForUUID(id)
+	// Report a link to the personal room
 	fmt.Fprintf(w, "%s", id.String())
 }
 

--- a/web-service/file_upload.go
+++ b/web-service/file_upload.go
@@ -7,14 +7,23 @@ import (
 	"log"
 	"mime/multipart"
 	"net/http"
+	//"net/url"
 	"os"
 	"path"
+	// TODO Make sure "NLP" is seen here.
+	// I want to see where the module comes from, not guess.
+	// See how guuid is imported
 	"project/python_wrappers"
+	guuid "github.com/google/uuid"
 )
 
 var (
 	WarningLogger *log.Logger
 	ErrorLogger   *log.Logger
+	UUIDInMemCache map[guuid.UUID]bool
+	// TODO remove this, leave UUIDResult
+	UUIDIsReadyForView map[guuid.UUID]bool
+	UUIDResult map[guuid.UUID][][]float32
 )
 
 func init() {
@@ -23,11 +32,58 @@ func init() {
 		log.Fatal(err)
 	}
 
+	if _, err := os.Stat("uploaded"); os.IsNotExist(err) {
+		// TODO 0777 is too much privilege, but it does not work with 0666.
+		err := os.Mkdir("uploaded", 0777)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	WarningLogger = log.New(file, "WARNING: ", log.Ldate|log.Ltime|log.Lshortfile)
 	ErrorLogger = log.New(file, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
+	UUIDInMemCache = make(map[guuid.UUID]bool)
+	UUIDIsReadyForView = make(map[guuid.UUID]bool)
+	UUIDResult = make(map[guuid.UUID][][]float32)
 }
 
-func uploadFile(w http.ResponseWriter, req *http.Request) {
+func prepareViewForUUID(id guuid.UUID) {
+	// TODO think about concurrency
+	UUIDInMemCache[id] = true
+	res, err := nlp.ComputePairwiseSimilarity("uploaded", "--external")
+	if err != nil {
+		ErrorLogger.Println(err)
+	}
+	UUIDIsReadyForView[id] = true
+	UUIDResult[id] = res
+}
+
+// Handlers
+
+func viewSimilarity(w http.ResponseWriter, req *http.Request) {
+	fmt.Println("viewSimilarity End Point hit")
+	// Retrieve view id
+	var id_ns, ok = req.URL.Query()["id"]
+	if !ok {
+		ErrorLogger.Println("Invalid url format")
+		return
+	}
+	id_str := id_ns[0]
+	id, err := guuid.Parse(id_str)
+	if err != nil {
+		ErrorLogger.Println("Invalid UUID value")
+		return
+	}
+	// If we are not ready, deny of service.
+	if _, err := UUIDIsReadyForView[id]; err == true {
+		fmt.Printf("Result for %s is not yet ready", id);
+		return
+	}
+	// Serve the result.
+	fmt.Println("%b", UUIDResult[id])
+}
+
+func uploadFiles(w http.ResponseWriter, req *http.Request) {
 	fmt.Println("File Upload Endpoint Hit")
 	var err error
 
@@ -66,28 +122,36 @@ func uploadFile(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		fmt.Printf("Uploaded File: %+v\n", fh.Filename)
-		fmt.Printf("File Size: %+v\n", fh.Size)
-		fmt.Printf("MIME Header: %+v\n", fh.Header)
-		fmt.Fprintf(w, "Successfully Uploaded File\n")
+		// fmt.Printf("Uploaded File: %+v\n", fh.Filename)
+		// fmt.Printf("File Size: %+v\n", fh.Size)
+		// fmt.Printf("MIME Header: %+v\n", fh.Header)
 	}
 
-	if res, err := nlp.ComputePairwiseSimilarity("uploaded", "--external"); err != nil {
-		ErrorLogger.Println(err)
-	} else {
-		fmt.Fprintf(w, "%v\n", res)
+	/// Report a link to the personal room
+
+	// TODO Fix concurrent access/modification
+	id := guuid.New()
+	for {
+		if _, ok := UUIDInMemCache[id]; ok {
+			id = guuid.New()
+			continue
+		}
+		break
 	}
+	go prepareViewForUUID(id)
+
+	fmt.Fprint(w, "%s", id.String())
 }
 
+// Necessary
+
 func setupRoutes() {
-	http.HandleFunc("/upload", uploadFile)
+	http.HandleFunc("/upload", uploadFiles)
+	http.HandleFunc("/view", viewSimilarity)
 	http.ListenAndServe(":8080", nil)
 }
 
 func main() {
 	fmt.Println("Hello World")
 	setupRoutes()
-
-	//res, err := nlp.ComputePairwiseSimilarity("uploaded", "--external")
-	//fmt.Println(res, err)
 }

--- a/web-service/go.mod
+++ b/web-service/go.mod
@@ -1,3 +1,5 @@
 module project
 
 go 1.15
+
+require github.com/google/uuid v1.1.2

--- a/web-service/go.sum
+++ b/web-service/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
Compute the semantic and structural difference in a separate
goroutine.

[TODO] Serve the results at view/ entry point.

Closes #25 

Signed-off-by: Artyom Gevorgyan <artemhevorhian@gmail.com>